### PR TITLE
chore/remove hardcoded parsing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## What has changed
+* 
+
+## Impediments
+* 

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Debug Launch Settings
+launchSettings.json

--- a/BooruDatasetGatherer/BooruDatasetGatherer.csproj
+++ b/BooruDatasetGatherer/BooruDatasetGatherer.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BooruSharp" Version="3.5.5" />
+		<PackageReference Include="System.Text.Json" Version="7.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/BooruDatasetGatherer/Data/BooruProfile.cs
+++ b/BooruDatasetGatherer/Data/BooruProfile.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace BooruDatasetGatherer.Data
 {
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
     public class BooruProfile
     {
         [JsonPropertyName("source")]
@@ -36,53 +35,5 @@ namespace BooruDatasetGatherer.Data
         public bool DownloadImages { get; set; } = false;
 
         public BooruProfile() { }
-
-        public void ParseSettings(Dictionary<string, string> settings)
-        {
-            foreach (string key in settings.Keys)
-            {
-                switch (key)
-                {
-                    case "source":
-                        Source = settings[key];
-                        break;
-                    case "batch":
-                    case "batchsize":
-                        if (int.TryParse(settings[key], out int batchSize))
-                            BatchSize = batchSize;
-                        break;
-                    case "filter":
-                        Filter = settings[key].Split(",").Select(x => x.Replace(" ", "")).ToArray();
-                        break;
-                    case "files":
-                    case "filefilters":
-                        FileFilters = settings[key].Split(",").Select(x => x.ToLower().Replace(" ", "")).ToArray();
-                        break;
-                    case "location":
-                    case "savelocation":
-                        if (Directory.Exists(settings[key]))
-                            SaveLocation = settings[key];
-                        break;
-                    case "threads":
-                        if (byte.TryParse(settings[key], out byte threads) && threads > 0 && threads < 64)
-                            Threads = threads;
-                        break;
-                    case "nsfw":
-                    case "maturecontent":
-                        if (bool.TryParse(settings[key], out bool nsfw))
-                            MatureContentAllowed = nsfw;
-                        break;
-                    case "size":
-                        if (int.TryParse(settings[key], out int size))
-                            TotalSize = size;
-                        break;
-                    case "download":
-                    case "downloadimages":
-                        if (bool.TryParse(settings[key], out bool download))
-                            DownloadImages = download;
-                        break;
-                }
-            }
-        }
     }
 }

--- a/BooruDatasetGatherer/Program.cs
+++ b/BooruDatasetGatherer/Program.cs
@@ -58,8 +58,11 @@ namespace BooruDatasetGatherer
                         profile = booruProfile;
                 }
             }
-
-            profile.ParseSettings(argMap);
+            else
+            {
+                string argJson = JsonSerializer.Serialize(argMap);
+                profile = JsonSerializer.Deserialize<BooruProfile>(argJson)!;
+            }
 
             if (string.IsNullOrEmpty(profile.Source))
                 return;

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Example: `--source safebooru --filter "1girl, confetti" --nsfw false`
 In [Examples](#examples) multiple examples are given for different purposes using the above mentioned arguments.
 
 ### Profiles
-To make it easier to repeat tasks, arguments can be contained inside a `.json` file. This is called a profile, with which you can easily load a certain set of arguments into the application without the need to pass any arguments yourself. Any argument that's passed with a `--profile` argument overrules the values inside the profile.
+To make it easier to repeat tasks, arguments can be contained inside a `.json` file. This is called a profile, with which you can easily load a certain set of arguments into the application without the need to pass any arguments yourself. Any argument that's passed with a `--profile` argument will be ignored.
 
-If in the `booruProfile` json the `size` argument is set to 20, it'll be overruled by the raw argument that's passed in. In this scenario
+If in the `booruProfile` json the `size` argument is set to 20, it'll overrule the raw argument that's passed in. In this scenario
 `--profile "booruProfile" --size 50`
-the `size` will be 50, even though 20 is defined in the `booruProfile`.
+the `size` will be 20, even though 50 is passed as an argument.
 
 A profile can look like this:
 ```json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Publish](https://github.com/Corruptex/booru-dataset-getherer/actions/workflows/publish.yml/badge.svg)](https://github.com/Corruptex/booru-dataset-getherer/actions/workflows/publish.yml)
 
 ## Summary
-<b>BooruDatasetGatherer</b> is an in .NET Core 3.1 Console application that aims to give the user an easy way to gather a large dataset from Booru based API's. With support for profiles, downloading images and gathering information inside a CSV dataset, it provides you with a set of tools to get you started with tagged Booru datasets for Machine Learning. The uses for this application could be for Object Recognition, Latent Diffusion, local Booru web-servers or other ends that require tagged images.
+<b>BooruDatasetGatherer</b> is an in .NET Core 3.1 written Console application that aims to give the user an easy way to gather a large dataset from Booru based API's. With support for profiles, downloading images and gathering information inside a CSV dataset, it provides you with a set of tools to get you started with tagged Booru datasets for Machine Learning. The uses for this application could be for Object Recognition, Latent Diffusion, local Booru web-servers or other ends that require tagged images.
 
 ## Quick Start
 Build the application using `dotnet build BooruDatasetGatherer` inside the cloned repository or use Visual Studio (Windows & Mac only) to compile a Debug or Release version.


### PR DESCRIPTION
## What has changed
* Removed hardcoded switch-case for parsing arguments
* Profiles are now leading, raw arguments will be discarded if a profile is passed

## Impediments
* Raw arguments will be discarded due to `System.Text.Json`'s lack of a `PopulateObject` method