### PR TITLE
feat: exception handling, removed hardcoded parsing and authentication

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## What has changed
+* 
+
+## Impediments
+* 

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Debug Launch Settings
+launchSettings.json

--- a/BooruDatasetGatherer/BooruDatasetGatherer.csproj
+++ b/BooruDatasetGatherer/BooruDatasetGatherer.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BooruSharp" Version="3.5.5" />
+		<PackageReference Include="System.Text.Json" Version="7.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/BooruDatasetGatherer/Data/BooruProfile.cs
+++ b/BooruDatasetGatherer/Data/BooruProfile.cs
@@ -11,14 +11,17 @@ namespace BooruDatasetGatherer.Data
         [JsonPropertyName("source")]
         public string Source { get; set; } = string.Empty;
 
+
         [JsonPropertyName("filter")]
         public string[] Filter { get; set; } = Array.Empty<string>();
 
         [JsonPropertyName("files")]
         public string[] FileFilters { get; set; } = { ".png", ".jpg", ".jpeg", ".gif", ".webp" };
 
+
         [JsonPropertyName("location")]
         public string SaveLocation { get; set; } = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Images");
+
 
         [JsonPropertyName("batch")]
         public int BatchSize { get; set; } = 20;
@@ -26,8 +29,10 @@ namespace BooruDatasetGatherer.Data
         [JsonPropertyName("size")]
         public int TotalSize { get; set; } = 1000;
 
+
         [JsonPropertyName("threads")]
         public byte Threads { get; set; } = 4;
+
 
         [JsonPropertyName("nsfw")]
         public bool MatureContentAllowed { get; set; } = false;

--- a/BooruDatasetGatherer/Data/BooruProfile.cs
+++ b/BooruDatasetGatherer/Data/BooruProfile.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace BooruDatasetGatherer.Data
 {
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
     public class BooruProfile
     {
         [JsonPropertyName("source")]
@@ -36,53 +35,5 @@ namespace BooruDatasetGatherer.Data
         public bool DownloadImages { get; set; } = false;
 
         public BooruProfile() { }
-
-        public void ParseSettings(Dictionary<string, string> settings)
-        {
-            foreach (string key in settings.Keys)
-            {
-                switch (key)
-                {
-                    case "source":
-                        Source = settings[key];
-                        break;
-                    case "batch":
-                    case "batchsize":
-                        if (int.TryParse(settings[key], out int batchSize))
-                            BatchSize = batchSize;
-                        break;
-                    case "filter":
-                        Filter = settings[key].Split(",").Select(x => x.Replace(" ", "")).ToArray();
-                        break;
-                    case "files":
-                    case "filefilters":
-                        FileFilters = settings[key].Split(",").Select(x => x.ToLower().Replace(" ", "")).ToArray();
-                        break;
-                    case "location":
-                    case "savelocation":
-                        if (Directory.Exists(settings[key]))
-                            SaveLocation = settings[key];
-                        break;
-                    case "threads":
-                        if (byte.TryParse(settings[key], out byte threads) && threads > 0 && threads < 64)
-                            Threads = threads;
-                        break;
-                    case "nsfw":
-                    case "maturecontent":
-                        if (bool.TryParse(settings[key], out bool nsfw))
-                            MatureContentAllowed = nsfw;
-                        break;
-                    case "size":
-                        if (int.TryParse(settings[key], out int size))
-                            TotalSize = size;
-                        break;
-                    case "download":
-                    case "downloadimages":
-                        if (bool.TryParse(settings[key], out bool download))
-                            DownloadImages = download;
-                        break;
-                }
-            }
-        }
     }
 }

--- a/BooruDatasetGatherer/Data/BooruProfile.cs
+++ b/BooruDatasetGatherer/Data/BooruProfile.cs
@@ -40,6 +40,15 @@ namespace BooruDatasetGatherer.Data
         [JsonPropertyName("download")]
         public bool DownloadImages { get; set; } = false;
 
+
+        [JsonPropertyName("username")]
+        public string Username { get; set; } = string.Empty;
+
+        [JsonPropertyName("passwordHash")]
+        public string Password { get; set; } = string.Empty;
+
+        public bool HasAuth { get { return !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password); } }
+
         public BooruProfile() { }
 
         public void ParseSettings(Dictionary<string, string> settings)

--- a/BooruDatasetGatherer/Data/BooruProfile.cs
+++ b/BooruDatasetGatherer/Data/BooruProfile.cs
@@ -41,6 +41,10 @@ namespace BooruDatasetGatherer.Data
         public bool DownloadImages { get; set; } = false;
 
 
+        [JsonPropertyName("exceptionLimit")]
+        public byte ExceptionLimit { get; set; } = 5;
+
+
         [JsonPropertyName("username")]
         public string Username { get; set; } = string.Empty;
 
@@ -101,6 +105,10 @@ namespace BooruDatasetGatherer.Data
                     case "passwordhash":
                     case "password":
                         Password = settings[key];
+                        break;
+                    case "exceptionlimit":
+                        if (byte.TryParse(settings[key], out byte limit))
+                            ExceptionLimit = limit;
                         break;
                 }
             }

--- a/BooruDatasetGatherer/Data/BooruProfile.cs
+++ b/BooruDatasetGatherer/Data/BooruProfile.cs
@@ -95,6 +95,13 @@ namespace BooruDatasetGatherer.Data
                         if (bool.TryParse(settings[key], out bool download))
                             DownloadImages = download;
                         break;
+                    case "username":
+                        Username = settings[key];
+                        break;
+                    case "passwordhash":
+                    case "password":
+                        Password = settings[key];
+                        break;
                 }
             }
         }

--- a/BooruDatasetGatherer/Factories/BooruFactory.cs
+++ b/BooruDatasetGatherer/Factories/BooruFactory.cs
@@ -1,4 +1,5 @@
-﻿using BooruSharp.Booru;
+﻿using BooruDatasetGatherer.Data;
+using BooruSharp.Booru;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,10 +34,15 @@ namespace BooruDatasetGatherer.Factories
 
         public bool Contains(string name) => Boorus.Contains(name);
 
-        public ABooru? GetBooru(string name)
+        public ABooru? GetBooru(BooruProfile profile)
         {
-            if (_boorus.ContainsKey(name))
-                return (ABooru)Activator.CreateInstance(_boorus[name])!;
+            if (_boorus.ContainsKey(profile.Source))
+            {
+                ABooru booru = (ABooru)Activator.CreateInstance(_boorus[profile.Source])!;
+                if (profile.HasAuth)
+                    booru.Auth = new BooruAuth(profile.Username, profile.Password);
+                return booru;
+            }
             return null;
         }
     }

--- a/BooruDatasetGatherer/Program.cs
+++ b/BooruDatasetGatherer/Program.cs
@@ -108,6 +108,7 @@ namespace BooruDatasetGatherer
         private static async Task GetPostsAsync(ABooru booruInstance, BooruProfile profile, StreamWriter stream, int total, int batch)
         {
             int processed = 0;
+            int exceptions = 0;
 
             while (processed < total)
             {
@@ -120,9 +121,17 @@ namespace BooruDatasetGatherer
                     else
                         results = await booruInstance.GetRandomPostsAsync(batch, profile.Filter);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     Console.WriteLine("Encountered an exception, continuing gathering a new batch.");
+
+                    exceptions++;
+                    if (exceptions > profile.ExceptionLimit)
+                    {
+                        Console.WriteLine($"Passed the exception limit of {profile.ExceptionLimit}, terminating thread.");
+                        break;
+                    }
+
                     processed -= batch;
                 }
                 finally

--- a/BooruDatasetGatherer/Program.cs
+++ b/BooruDatasetGatherer/Program.cs
@@ -74,7 +74,7 @@ namespace BooruDatasetGatherer
             Console.WriteLine("Running with settings: \n");
             Console.WriteLine(JsonSerializer.Serialize(profile, new JsonSerializerOptions { WriteIndented = true }));
 
-            ABooru booru = factory.GetBooru(profile.Source)!;
+            ABooru booru = factory.GetBooru(profile)!;
             if (!booru.HasMultipleRandomAPI)
             {
                 Console.WriteLine("Selected source does not support getting random posts. Exiting.");
@@ -95,7 +95,7 @@ namespace BooruDatasetGatherer
                 await stream.WriteLineAsync("FILEURL, PREVIEWURL, POSTURL, SAMPLEURI, RATING, TAGS, ID, HEIGHT, WIDTH, PREVIEWHEIGHT, PREVIEWWIDTH, CREATION, SOURCE, SCORE, MD5, LOCATION");
 
                 for (int i = 0; i < threads.Length; i++)
-                    threads[i] = GetPostsAsync(factory.GetBooru(profile.Source)!, profile, stream, perThread, profile.BatchSize);
+                    threads[i] = GetPostsAsync(factory.GetBooru(profile)!, profile, stream, perThread, profile.BatchSize);
 
                 await Task.WhenAll(threads);
             }

--- a/BooruDatasetGatherer/Program.cs
+++ b/BooruDatasetGatherer/Program.cs
@@ -58,8 +58,11 @@ namespace BooruDatasetGatherer
                         profile = booruProfile;
                 }
             }
-
-            profile.ParseSettings(argMap);
+            else
+            {
+                string argJson = JsonSerializer.Serialize(argMap);
+                profile = JsonSerializer.Deserialize<BooruProfile>(argJson)!;
+            }
 
             if (string.IsNullOrEmpty(profile.Source))
                 return;

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Example: `--source safebooru --filter "1girl, confetti" --nsfw false`
 | `batch`   | `int`     | The size that a batch is allowed to be. The total size is split among threads, the split size will be divided by the batch size in to cycles (`50`, `15`) | `20` | :heavy_multiplication_x: |
 | `threads` | `byte`    | The amount of threads to split the dataset gathering task with (`4`, `16`) | `4` | :heavy_multiplication_x: |
 | `nsfw`    | `bool`    | If enabled, images that contain Not Safe For Work (NSFW) content will be saved into the dataset and downloaded if `download` is enabled (`true`, `0`) | `false` | :heavy_multiplication_x: |
-| `profile` | `string`  | The location (or name if located in the same folder) of the `.json` file containing a valid profile, more info in section [Profiles](#profiles) (`C:\booruProfile.json`, `booruProfile`) |    | :heavy_multiplication_x: |  
+| `profile` | `string`  | The location (or name if located in the same folder) of the `.json` file containing a valid profile, more info in section [Profiles](#profiles) (`C:\booruProfile.json`, `booruProfile`) |    | :heavy_multiplication_x: |
+| `username`| `string`  | The username of the Booru account that you wish to authenticate with (`"My Username"`, `my_username`) |   | :heavy_multiplication_x: |
+| `passwordHash`| `string`  | The password used to authenticate yourself at the given source. Note: this can be your password hash, API key or a different key, depending on the Booru of your choosing. More info at [Authentication](#authentication) (`"{password_hash}"`, `{api_key}`). | `{Executing Folder}/Images` | :heavy_multiplication_x: |
 
 In [Examples](#examples) multiple examples are given for different purposes using the above mentioned arguments.
 
@@ -102,9 +104,14 @@ A set of examples to help you get on your way to using this tool.
 ---profile "safeBooruProfile"
 ```
 
+### With authentication
+```powershell
+---source safebooru --username "{username}" --passwordHash "{password_hash}"
+```
+
 ### Customizing all parameters
 ```powershell
---profile safebooru --filter "1boy, confetti, celebrating" --size 1500 --batch 25 --threads 16 --download true --nsfw false --location "C:/Dataset" --files ".jpg, .jpeg"
+--source safebooru --filter "1boy, confetti, celebrating" --size 1500 --batch 25 --threads 16 --download true --nsfw false --location "C:/Dataset" --files ".jpg, .jpeg"
 ```
 
 ## Supported Boorus
@@ -131,6 +138,9 @@ The output of these Boorus are generic and will not differ, it can occur that a 
 ```
 FILEURL, PREVIEWURL, POSTURL, SAMPLEURI, RATING, TAGS, ID, HEIGHT, WIDTH, PREVIEWHEIGHT, PREVIEWWIDTH, CREATION, SOURCE, SCORE, MD5, LOCATION
 ```
+
+## Authentication
+Since BooruSharp supports authentication, this application also supports this feature. By passing along a `--username` and `--passwordHash` you can authenticate yourself to the given Booru source. The different methods of authentication and which Booru supports it, you should consult the BooruSharp `README.md`, under the section [Authentication](https://github.com/Xwilarg/BooruSharp#authentification).
 
 ## Future
 Since this application is made to gather information, a few things are on the road-map to further enhance that core feature. This includes:

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Example: `--source safebooru --filter "1girl, confetti" --nsfw false`
 In [Examples](#examples) multiple examples are given for different purposes using the above mentioned arguments.
 
 ### Profiles
-To make it easier to repeat tasks, arguments can be contained inside a `.json` file. This is called a profile, with which you can easily load a certain set of arguments into the application without the need to pass any arguments yourself. Any argument that's passed with a `--profile` argument overrules the values inside the profile.
+To make it easier to repeat tasks, arguments can be contained inside a `.json` file. This is called a profile, with which you can easily load a certain set of arguments into the application without the need to pass any arguments yourself. Any argument that's passed with a `--profile` argument will be ignored.
 
-If in the `booruProfile` json the `size` argument is set to 20, it'll be overruled by the raw argument that's passed in. In this scenario
+If in the `booruProfile` json the `size` argument is set to 20, it'll overrule the raw argument that's passed in. In this scenario
 `--profile "booruProfile" --size 50`
-the `size` will be 50, even though 20 is defined in the `booruProfile`.
+the `size` will be 20, even though 50 is passed as an argument.
 
 A profile can look like this:
 ```json

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Example: `--source safebooru --filter "1girl, confetti" --nsfw false`
 | `threads` | `byte`    | The amount of threads to split the dataset gathering task with (`4`, `16`) | `4` | :heavy_multiplication_x: |
 | `nsfw`    | `bool`    | If enabled, images that contain Not Safe For Work (NSFW) content will be saved into the dataset and downloaded if `download` is enabled (`true`, `0`) | `false` | :heavy_multiplication_x: |
 | `profile` | `string`  | The location (or name if located in the same folder) of the `.json` file containing a valid profile, more info in section [Profiles](#profiles) (`C:\booruProfile.json`, `booruProfile`) |    | :heavy_multiplication_x: |
+| `exceptionLimit` | `byte`  | The amount of exceptions that can occur inside a thread. (`14`, `"20"`) | `5` | :heavy_multiplication_x: |
 | `username`| `string`  | The username of the Booru account that you wish to authenticate with (`"My Username"`, `my_username`) |   | :heavy_multiplication_x: |
 | `passwordHash`| `string`  | The password used to authenticate yourself at the given source. Note: this can be your password hash, API key or a different key, depending on the Booru of your choosing. More info at [Authentication](#authentication) (`"{password_hash}"`, `{api_key}`). | `{Executing Folder}/Images` | :heavy_multiplication_x: |
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Publish](https://github.com/Corruptex/booru-dataset-getherer/actions/workflows/publish.yml/badge.svg)](https://github.com/Corruptex/booru-dataset-getherer/actions/workflows/publish.yml)
 
 ## Summary
-<b>BooruDatasetGatherer</b> is an in .NET Core 3.1 Console application that aims to give the user an easy way to gather a large dataset from Booru based API's. With support for profiles, downloading images and gathering information inside a CSV dataset, it provides you with a set of tools to get you started with tagged Booru datasets for Machine Learning. The uses for this application could be for Object Recognition, Latent Diffusion, local Booru web-servers or other ends that require tagged images.
+<b>BooruDatasetGatherer</b> is an in .NET Core 3.1 written Console application that aims to give the user an easy way to gather a large dataset from Booru based API's. With support for profiles, downloading images and gathering information inside a CSV dataset, it provides you with a set of tools to get you started with tagged Booru datasets for Machine Learning. The uses for this application could be for Object Recognition, Latent Diffusion, local Booru web-servers or other ends that require tagged images.
 
 ## Quick Start
 Build the application using `dotnet build BooruDatasetGatherer` inside the cloned repository or use Visual Studio (Windows & Mac only) to compile a Debug or Release version.


### PR DESCRIPTION
## What has changed
* Added exception handling and limits to the Booru collecting threads
* Removed the hardcoded switch-case of parsing the `argMap` `Dictionary`
* Users have the ability to pass their authentication

## Impediments
* Exception limit is per-thread, not a collective limit
* Profiles now overrule all raw passed arguments, when a profile is given, no raw arguments will be used