### PR TITLE
fix(program): fixed results being set to empty in the finally cclause

### DIFF
--- a/BooruDatasetGatherer/Program.cs
+++ b/BooruDatasetGatherer/Program.cs
@@ -124,7 +124,7 @@ namespace BooruDatasetGatherer
                     else
                         results = await booruInstance.GetRandomPostsAsync(batch, profile.Filter);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     Console.WriteLine("Encountered an exception, continuing gathering a new batch.");
 
@@ -136,9 +136,6 @@ namespace BooruDatasetGatherer
                     }
 
                     processed -= batch;
-                }
-                finally
-                {
                     results = Array.Empty<SearchResult>();
                 }
 


### PR DESCRIPTION
## What has changed
* Fix for results not being parsed due to a `finally` clause setting the results to an empty array

## Impediments
* None